### PR TITLE
slate-cli section generator

### DIFF
--- a/generators/new-section/includes/questions.js
+++ b/generators/new-section/includes/questions.js
@@ -1,0 +1,19 @@
+module.exports = {
+  section: function(generator) {
+    var questions = [];
+
+    if (!generator.dirname) {
+      questions.unshift({
+        type: 'input',
+        name: 'dirname',
+        message: 'Please enter a name for your section (folder will be created)',
+        validate: function(answer) {
+          return answer
+            ? true
+            : 'You must provide a name for your section.';
+        }
+      });
+    }
+    return questions;
+  }
+};

--- a/generators/new-section/section.js
+++ b/generators/new-section/section.js
@@ -1,0 +1,44 @@
+var generators = require('yeoman-generator');
+var questions = require('./includes/questions.js');
+
+module.exports = generators.Base.extend({
+
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+
+    this.argument('path', {type: String, required: true});
+    this.argument('dirname', {type: String, required: false});
+  },
+
+  prompting: function() {
+    return this.prompt(questions.section(this))
+      .then(function(answers) {
+        if (answers.dirname) {
+          this.dirname = answers.dirname;
+        }
+      }.bind(this));
+  },
+
+  configuring: function() {
+    this.destinationRoot(this.path + '/src/sections/' + this.dirname);
+  },
+
+  writing: function() {
+    var readFiles = [
+      this.templatePath('javascript.js'),
+      this.templatePath('schema.json'),
+      this.templatePath('style.liquid'),
+      this.templatePath('template.liquid')
+    ];
+    var writeFiles = [
+      this.destinationPath('javascript.js'),
+      this.destinationPath('schema.json'),
+      this.destinationPath('style.liquid'),
+      this.destinationPath('template.liquid')
+    ];
+
+    for (var i = 0; i < readFiles.length; i++) {
+      this.fs.copyTpl(readFiles[i], writeFiles[i], {});
+    }
+  }
+});

--- a/generators/new-section/templates/javascript.js
+++ b/generators/new-section/templates/javascript.js
@@ -1,0 +1,8 @@
+/*
+  Section JS is concatenated together into a single file and loaded with a `defer` tag.
+  Script execution will not run until the page has finished parsing.
+
+  You cannot use liquid tags here. If you need access to section settings, you should
+  use data attributes on HTML elements in `template.liquid` and can reference those
+  attributes from within this file to access any required information.
+*/

--- a/generators/new-section/templates/schema.json
+++ b/generators/new-section/templates/schema.json
@@ -1,0 +1,8 @@
+{
+  "settings": [],
+  "presets": [{
+    "name": "Section preset",
+    "category": "Miscellaneous"
+  }],
+  "blocks" : {}
+}

--- a/generators/new-section/templates/style.liquid
+++ b/generators/new-section/templates/style.liquid
@@ -1,0 +1,12 @@
+<style>
+  /*
+    Section settings are only accessible in CSS through inline <style> blocks.
+
+    You can access section settings directly using liquid tags here.
+    Include `section.id` or `block.id` in your selector to ensure the css applies to
+    the correct instance.
+      E.g. `.element-{{ section.id }} {}`.
+
+    If you don't need to access any section settings in CSS, you can delete this file.
+  */
+</style>

--- a/generators/new-section/templates/template.liquid
+++ b/generators/new-section/templates/template.liquid
@@ -1,0 +1,4 @@
+{% comment %}
+  Define your section markup, using `section.settings.[setting_name]` to access specific settings.
+  * Sections do not have access to global liquid variables.
+{% endcomment %}

--- a/generators/slate-shopify/includes/questions.js
+++ b/generators/slate-shopify/includes/questions.js
@@ -38,8 +38,8 @@ module.exports = {
         message: 'Please enter a name for your theme (folder will be created)',
         validate: function(answer) {
           return answer
-            ? 'You must provide a name for your theme.'
-            : true;
+            ? true
+            : 'You must provide a name for your theme.';
         }
       });
     }

--- a/lib/commands/new.js
+++ b/lib/commands/new.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var findRoot = require('find-root');
 var utils = require('../includes/utils.js');
 var msg = require('../includes/messages.js');
 
@@ -10,9 +11,20 @@ module.exports = function(args/*, options*/) {
     process.stdout.write(msg.noGenerator());
 
   } else {
+    var scriptArgs;
+
     switch (args[0]) {
     case 'theme':
-      var scriptArgs = ['generate-theme', destRoot];
+      scriptArgs = ['generate-theme', destRoot];
+      if (args[1]) {
+        scriptArgs.push(args[1]);
+      }
+      utils.runScript(slateRoot, scriptArgs);
+      break;
+
+    case 'section':
+      var themeRoot = findRoot(destRoot);
+      scriptArgs = ['generate-section', themeRoot];
       if (args[1]) {
         scriptArgs.push(args[1]);
       }

--- a/lib/includes/messages.js
+++ b/lib/includes/messages.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   generatorsList: function() {
-    return ' slate new theme\n';
+    return ' slate new theme\n slate new section\n';
   },
 
   unknownInstaller: function() {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0; exit 0",
-    "generate-theme": "yo ./generators/slate-shopify/theme.js"
+    "generate-theme": "yo ./generators/slate-shopify/theme.js",
+    "generate-section": "yo ./generators/new-section/section.js"
   },
   "dependencies": {
     "bin-wrapper": "3.0.2",


### PR DESCRIPTION
- generates a new section scaffold in the current theme's `src/sections/` directory
- fixed a bug with theme generation when no name was provided.

You can test this by pulling this branch into your `npm-link`ed slate-cli repo and running `slate new section <section-name>` from inside a slate theme directory.  

If you also pull the (section workflow branch)[https://github.com/Shopify/slate/pull/350] from the Slate repo, you can run this in conjunction with the `slate watch` task to see the fully functioning workflow.

@Shopify/themes-fed @macdonaldr93 
