### PR TITLE
Add error when themekit isn't setup

### DIFF
--- a/commands/remove.js
+++ b/commands/remove.js
@@ -5,6 +5,9 @@ module.exports = function(args) {
   if (args.length === 0) {
     process.stdout.write(msg.noFiles());
   } else {
-    themekit.commands(['remove'].concat(args));
+    themekit.test()
+      .then(function() {
+        return themekit.commands(['remove'].concat(args));
+      });
   }
 };

--- a/commands/replace.js
+++ b/commands/replace.js
@@ -1,7 +1,9 @@
-var msg = require('../includes/messages.js');
 var themekit = require('../includes/themekit.js');
 
 module.exports = function() {
   // add environment param
-  themekit.commands(['replace']);
+  themekit.test()
+    .then(function() {
+      return themekit.commands(['replace']);
+    });
 };

--- a/commands/upload.js
+++ b/commands/upload.js
@@ -5,6 +5,9 @@ module.exports = function(args) {
   if (args.length === 0) {
     process.stdout.write(msg.noFiles());
   } else {
-    themekit.commands(['upload'].concat(args));
+    themekit.test()
+      .then(function() {
+        return themekit.commands(['upload'].concat(args));
+      });
   }
 };

--- a/includes/messages.js
+++ b/includes/messages.js
@@ -9,6 +9,10 @@ module.exports = {
     return 'No files provided\n';
   },
 
+  missingDependencies: function() {
+    return 'Dependencies missing. Please run slate setup\n';
+  },
+
   noGenerator: function() {
     return 'No generator specified, please use one of the following commands:\n ' + this.generatorsList();
   },

--- a/includes/themekit.js
+++ b/includes/themekit.js
@@ -1,4 +1,7 @@
+var Promise = require('bluebird');
+var stat = Promise.promisify(require('fs').stat);
 var path = require('path');
+var msg = require('./messages.js');
 var BinWrapper = require('bin-wrapper');
 var spawn = require('child_process').spawn;
 var slateRoot = path.resolve(__dirname, '..');
@@ -44,6 +47,18 @@ module.exports = {
         }
       });
     });
+  },
+
+  test: function() {
+    return stat(this.path())
+      .catch(function(err) {
+        if (err.code === 'ENOENT') {
+          process.stdout.write(msg.missingDependencies());
+          process.exit(5);
+        } else {
+          throw new Error(err);
+        }
+      });
   },
 
   /**


### PR DESCRIPTION
@Shopify/themes-fed 

This adds an error for slate commands for when ThemeKit hasn't been setup. Colouring is a bit off but @m-ux has a branch with chalk and we'll fix up the errors when that comes in.
