### PR TITLE
Remove README section and reformat getting started steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ cd slate-cli
 #### 2. Run `npm link`
 This will install both run-time project dependencies and developer tools listed in the [package.json](package.json) file. It also creates a symbolic link from this project to your global npm directory.
 
+#### 3. Run `slate setup`
+This will install project specific dependencies and developer tools.
+
 ## Global Options
 
 #### Help `-h, --help`


### PR DESCRIPTION
Updated the "Getting Started" steps.

Also, moving the "Creating a New Theme" section to the Slate repository. This way the Slate-CLI README focuses on: 1. installing the CLI and 2. a list of commands.

@Shopify/themes-fed 
