### PR TITLE
Fix custom env default env choices

### DIFF
--- a/generators/new-theme/includes/questions.js
+++ b/generators/new-theme/includes/questions.js
@@ -114,6 +114,13 @@ function hasGitRepo(answers) {
  * @private
  */
 function getDefaultEnvSelect(answers) {
+  var hasCustom = hasCustomEnvironments(answers);
+  
+  if (hasCustom) {
+    answers.environments.pop(); // removes `custom` selection
+    answers.environments = answers.environments.concat(answers.customEnv.split(/,\s*/));
+  }
+  
   return answers.environments;
 }
 


### PR DESCRIPTION
@Shopify/themes-fed this will just break out "custom" into the actual list of custom envs for the user to select.
