### PR TITLE
Remove options from slate new command

### DIFF
--- a/commands/new.js
+++ b/commands/new.js
@@ -39,7 +39,7 @@ module.exports = {
   },
   help: function() {
     utils.logHelpMsg([
-      'Usage: slate new [args] [--options]',
+      'Usage: slate new [args]',
       '',
       'Scaffold a theme or section.',
       '',


### PR DESCRIPTION
We don't have options for the `slate new` command.

@Shopify/themes-fed 
