### PR TITLE
Fix blocks must be an array error

### DIFF
--- a/generators/new-section/templates/schema.json
+++ b/generators/new-section/templates/schema.json
@@ -4,5 +4,5 @@
     "name": "Section preset",
     "category": "Miscellaneous"
   }],
-  "blocks" : {}
+  "blocks" : []
 }


### PR DESCRIPTION
Fixes blocks must be an array error for sections.

![image](https://cloud.githubusercontent.com/assets/991693/17485905/157e46e2-5d5d-11e6-8b67-b7d1258e8c44.png)

@Shopify/themes-fed 
