### PR TITLE
Use SSH github URL to in get started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to run commands to generate, set up, and deploy Shopify themes.
 #### 1. Get the latest version
 Clone the latest version of Slate CLI to your local machine by running:
 ```shell
-git clone https://github.com/Shopify/slate-cli
+git clone git@github.com:Shopify/slate-cli.git
 cd slate-cli
 ```
 


### PR DESCRIPTION
Not sure if this was intended behaviour, but I'd expect the SSH github URL in the get started guide. 😄 

@m-ux @Shopify/themes-fed 
