### PR TITLE
Disable Yeoman insights and update notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "scripts": {
     "lint": "eslint . --config '.eslintrc.yml' --ignore-path '.eslintignore' --max-warnings 0; exit 0",
-    "generate-theme": "yo ./generators/new-theme/theme.js",
-    "generate-section": "yo ./generators/new-section/section.js"
+    "generate-theme": "yo --no-insight --no-update-notifier ./generators/new-theme/theme.js",
+    "generate-section": "yo --no-insight --no-update-notifier ./generators/new-section/section.js"
   },
   "dependencies": {
     "Slate": "git+ssh://git@github.com/shopify/slate.git#c8b8d597c58b85b6472cf5faac213f09f3d806c2",


### PR DESCRIPTION
https://github.com/yeoman/yo#options

> `--[no-]insight` - Toggle anonymous Insight tracking which helps us improve Yeoman. Using either of these flags on the first run will prevent you from being prompted about it interactively. The flags can also be used to change it later on.

https://github.com/yeoman/update-notifier#user-settings

> Users can also opt-out by setting the environment variable `NO_UPDATE_NOTIFIER` with any value or by using the `--no-update-notifier` flag on a per run basis.

r @macdonaldr93 
