### PR TITLE
Remove trailing space from noGenerator() message

### DIFF
--- a/includes/messages.js
+++ b/includes/messages.js
@@ -18,7 +18,7 @@ module.exports = {
   },
 
   noGenerator: function() {
-    return 'No generator specified, please use one of the following commands:\n ' + this.generatorsList();
+    return 'No generator specified, please use one of the following commands:\n' + this.generatorsList();
   },
 
   unknownGenerator: function() {


### PR DESCRIPTION
Changes this

```
❯ slate new
No generator specified, please use one of the following commands:
  slate new theme
 slate new section
```

to

```
❯ slate new
No generator specified, please use one of the following commands:
 slate new theme
 slate new section
```

r @macdonaldr93
