### PR TITLE
Quick fix: ThemeKit Update

### DIFF
--- a/includes/themekit.js
+++ b/includes/themekit.js
@@ -38,7 +38,7 @@ module.exports = {
    */
   install: function() {
     var exists = true;
-    
+
     return stat(this.path())
       .catch(function(err) {
         if (err.code === 'ENOENT') {
@@ -67,7 +67,7 @@ module.exports = {
             }
           });
         });
-      }.bind(this));
+      });
   },
 
   test: function() {


### PR DESCRIPTION
# @Shopify/themes-fed

This is a quick fix to remove the ThemeKit binary if it exists so that it properly updates if you run `slate setup` again.

This should eventually be properly handled by `slate update`.
