### PR TITLE
Fix bracket output

### DIFF
--- a/includes/utils.js
+++ b/includes/utils.js
@@ -17,7 +17,12 @@ module.exports = {
   runScript: function(dir, script) {
     npm.load({prefix: dir, loglevel: 'silent'}, function(err) {
       if (err) { throw err; }
-      npm.commands.run(script);
+
+      npm.commands.run(script, function(runErr, output) { // eslint-disable-line no-unused-vars
+        if (runErr) { throw runErr; }
+
+        output = null;
+      });
     });
   }
 };


### PR DESCRIPTION
@Shopify/themes-fed 

Definitely need to understand what `output` could potentially output but it seems like all errors and other responses do not get silenced by this. It's only the output of `.run` which was that weird bracket thing.

Fixes #45
