### PR TITLE
Add note to comment out unused environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Slate CLI
 [![CircleCI](https://circleci.com/gh/Shopify/slate-cli.svg?style=svg&circle-token=83ed3f203115767f7bc4e6f3be07cb93788f4bd2)](https://circleci.com/gh/Shopify/slate-cli)
 
-Slate is a command line tool for Shopify Theme development.  It's designed to assist your development workflow 
+Slate is a command line tool for Shopify Theme development.  It's designed to assist your development workflow
 and speed up the process of developing, testing and deploying themes to Shopify stores.
 
 ### Table of Contents
@@ -16,7 +16,7 @@ and speed up the process of developing, testing and deploying themes to Shopify 
 ## Installation
 
 #### 1. Get the latest version
-Clone the latest version of Slate CLI to your local machine using SSH 
+Clone the latest version of Slate CLI to your local machine using SSH
 (see [github's guide to SSH](https://help.github.com/articles/generating-an-ssh-key/) for help):
 
 ```shell
@@ -32,7 +32,7 @@ npm link
 ```
 _note: if you get an **`EACCES`** error, you may need to run `sudo npm link` instead_
 
-This command installs node dependencies (equivalent to running `npm install`) and creates 
+This command installs node dependencies (equivalent to running `npm install`) and creates
 a symbolic link to your global npm directory.
 
 You should now be able to run slate from your terminal. Try running `slate -v` to verify that everything worked
@@ -55,24 +55,24 @@ Run the following commands to create a new project:
 slate new theme <my-theme-name>
 ```
 
-You will be prompted with some questions to help configure your theme.  A new directory will be created within the 
+You will be prompted with some questions to help configure your theme.  A new directory will be created within the
 current directory (similar to `git clone`).
 
 Once the boilerplate has been generated, Slate runs `npm install` to download remaining dependencies (~1min).
 
 #### 2. Configure your Store / Environment settings
 When the theme generator has finished, the theme's `config.yml` file will open automatically.
-You will need to fill in the required fields for each store / environment.
+You will need to fill in the required fields for each store / environment. Comment out any environments that you want to set up later or Theme Kit will throw an error.
 
-> _For more details on configuring your environments please see our 
+> _For more details on configuring your environments please see our
 **[Store configuration guide](https://github.com/Shopify/slate-cli/blob/master/store-configuration.md)**._
 
 #### 3. Navigating the codebase
 
-The [`/src`](https://github.com/Shopify/slate/tree/master/src) directory is where you develop your theme. It includes 
-the [standard Theme structure](https://help.shopify.com/themes/development/templates), and a few additional folders. 
+The [`/src`](https://github.com/Shopify/slate/tree/master/src) directory is where you develop your theme. It includes
+the [standard Theme structure](https://help.shopify.com/themes/development/templates), and a few additional folders.
 
-The contents of `/src` will be compiled into a `dist/` directory during most slate tasks. The compiled files in `/dist` 
+The contents of `/src` will be compiled into a `dist/` directory during most slate tasks. The compiled files in `/dist`
 are the files that will be uploaded to your store.
 
 Some new folders have been included in the `/src` directory:
@@ -84,17 +84,17 @@ Some new folders have been included in the `/src` directory:
 
 #### 4. Start developing your Theme
 You're ready to start developing with Slate.  To get started, run the following command from your theme directory:
- 
+
  ```shell
  slate start
  ```
- 
- This will build your theme from the `/src` contents to the format required by Shopify (outputs a `/dist` directory). 
- 
- The `/dist` folder will be uploaded to the store / theme_id specified in your default environment. 
- 
- A [Browsersync](https://browsersync.io/) proxy will run when deployment is complete and automatically launch in your browser. 
- Slate will begin watching your theme directory for file changes and deploy them to your store whenever you make a change.  Browsersync 
+
+ This will build your theme from the `/src` contents to the format required by Shopify (outputs a `/dist` directory).
+
+ The `/dist` folder will be uploaded to the store / theme_id specified in your default environment.
+
+ A [Browsersync](https://browsersync.io/) proxy will run when deployment is complete and automatically launch in your browser.
+ Slate will begin watching your theme directory for file changes and deploy them to your store whenever you make a change.  Browsersync
  will live-reload as soon as your changes are deployed.
 
 ## Updating Slate
@@ -102,8 +102,8 @@ You're ready to start developing with Slate.  To get started, run the following 
 1. Pull the latest version from GitHub - Make sure that your current branch is master and that your master branch is up-to-date.
 2. Run `npm update` - This will update all project dependencies and developer tools listed in the [package.json](package.json) file.
 3. Run `slate setup` - This installs project-specific dependencies and developer tools. More details [here](#setup).
-4. Run `npm prune` and `npm install` (optional) - After major changes, it may be necessary to clean out your `node_modules` and 
-make sure that new modules have been correctly installed. 
+4. Run `npm prune` and `npm install` (optional) - After major changes, it may be necessary to clean out your `node_modules` and
+make sure that new modules have been correctly installed.
 
    This will remove any unused dependencies from `node_modules` and install all new dependencies.
 
@@ -140,7 +140,7 @@ Generates a new section folder in `src/sections` and the four files that will ma
 
 See the [Shopify liquid documentation](https://help.shopify.com/themes/development/storefront-editor/sections) for more information on section syntax.
 
-### help 
+### help
 ```
 slate [command] -h, slate [command] --help
 ```
@@ -215,8 +215,8 @@ slate watch [--options]
 
 Sets up the watchers for all theme assets.
 
-By default, [Browsersync](https://browsersync.io/) will launch a new browser tab at 
-[https://localhost:3000](https://localhost:3000) and watch for any files changes. You can ignore this 
+By default, [Browsersync](https://browsersync.io/) will launch a new browser tab at
+[https://localhost:3000](https://localhost:3000) and watch for any files changes. You can ignore this
 by passing the `--nosync` option to the command.
 
 #### options
@@ -230,8 +230,8 @@ by passing the `--nosync` option to the command.
 slate zip
 ```
 
-Performs a fresh build of your theme and zips it into a file that's compatible with Shopify. 
-The zip file can be found within an upload folder that is generated within your theme project root folder. 
+Performs a fresh build of your theme and zips it into a file that's compatible with Shopify.
+The zip file can be found within an upload folder that is generated within your theme project root folder.
 The zip is overwritten each time you use this command and is not meant to be used for versioning.
 
 ## Troubleshooting


### PR DESCRIPTION
Added "Comment out any environments that you want to set up later or Theme Kit will throw an error." around environments so that Theme Kit won't throw errors on unsuspecting users.

@m-ux 
