### PR TITLE
Save exact version of slate tools on theme gen

### DIFF
--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -38,7 +38,7 @@ export default function(program) {
 
           writePackageJsonSync(pkg, name);
 
-          return startProcess('npm', ['install', '@shopify/slate-tools', '-D'], {
+          return startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
             cwd: root,
           });
         })


### PR DESCRIPTION
@Shopify/themes-fed 

Save exact version so that their theme won't change from dev to dev.