### PR TITLE
Revert theme name to optional

### DIFF
--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -8,7 +8,7 @@ import {downloadFromUrl, unzip, startProcess, writePackageJsonSync} from '../uti
 
 export default function(program) {
   program
-    .command('theme <name>')
+    .command('theme [name]')
     .alias('t')
     .description('Generates a new theme directory containing Slate\'s theme boilerplate.')
     .action(async function(name) {


### PR DESCRIPTION
@Shopify/themes-fed @cshold 

Reverting this to optional... otherwise prompt can't run. If it's undefined the CLI asks what you would like to define.