### PR TITLE
fixes broken babel output on some platforms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,9 +70,12 @@ const isSlateTheme = (themeRoot && checkForSlateTools(themeRoot));
 if (isSlateTheme) {
   const slateToolsCommands = join(themeRoot, normalize('/node_modules/@shopify/slate-tools/lib/commands'));
 
+  /* eslint-disable no-useless-escape */
   readdirSync(slateToolsCommands)
-    .filter((file) => ~file.search(/^[^\.].*\.js$/)) // eslint-disable-line no-useless-escape
+    .filter((file) => ~file.search(/^[^\.].*\.js$/))
     .forEach((file) => require(join(slateToolsCommands, file)).default(program));
+
+  /* eslint-enable no-useless-escape */
 }
 
 


### PR DESCRIPTION
@m-ux @macdonaldr93 @cshold 

Fixes an issue where the compiled babel output for slate tools in `slate` throws an error on shipit (and I'm assuming other linux environments).  


shipit error:
<img width="1618" alt="screenshot 2016-11-23 10 56 44" src="https://cloud.githubusercontent.com/assets/1938373/20572386/44f8e02e-b179-11e6-8160-07b4d69a5fb0.png">

babel compiled index.js:
![screenshot 2016-11-23 12 33 38](https://cloud.githubusercontent.com/assets/1938373/20572383/428457e2-b179-11e6-8f6b-a83407e2fb69.png)

new babel compiled output:

```javascript
if (isSlateTheme) {
  (function () {
    var slateToolsCommands = (0, _path.join)(themeRoot, (0, _path.normalize)('/node_modules/@shopify/slate-tools/lib/commands'));

    /* eslint-disable no-useless-escape */
    (0, _fs.readdirSync)(slateToolsCommands).filter(function (file) {
      return ~file.search(/^[^\.].*\.js$/);
    }).forEach(function (file) {
      return require((0, _path.join)(slateToolsCommands, file)).default(_commander2.default);
    });

    /* eslint-enable no-useless-escape */
  })();
}```