### PR TITLE
Bump commander version for alias spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "author": "Shopify Inc.",
   "dependencies": {
-    "@shopify/commander": "2.9.1",
+    "@shopify/commander": "2.9.2",
     "babel-polyfill": "6.16.0",
     "chalk": "1.1.3",
     "cross-spawn": "5.0.1",


### PR DESCRIPTION
@Shopify/themes-fed @cshold 

Bumping this so that:

```
Commands:

    theme|t [name]  Generates a new theme directory containing Slate's theme boilerplate.
```

becomes:

```
Commands:

    theme | t [name]  Generates a new theme directory containing Slate's theme boilerplate.
```