### PR TITLE
Add test command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Performs a full deploy of your theme (see [slate deploy](#deploy)) and starts th
 slate test
 ```
 
-Uses the [@shopify/theme-lint](https://github.com/Shopify/theme-lint) package to run translations tests on your locales found in the `/src/locales` folder. The package checks for untranslated keys inside of your Liquid templates, missing translation keys in specific locale files, and translation key HTML validity.
+Uses the [@shopify/theme-lint](https://github.com/Shopify/theme-lint) package to run translation tests on your locales found in the `/src/locales` folder. The package checks for untranslated keys inside of your Liquid templates, missing translation keys in specific locale files, and translation key HTML validity.
 
 ### watch
 ```

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Command               | Usage
 [build](#build)       | `slate build`
 [deploy](#deploy)     | `slate deploy [--options]`
 [start](#start)       | `slate start [--options]`
+[test](#test)         | `state test`
 [watch](#watch)       | `slate watch [--options]`
 [zip](#zip)           | `slate zip`
 
@@ -167,6 +168,13 @@ Performs a full deploy of your theme (see [slate deploy](#deploy)) and starts th
 ```
 -e, --env  deploy to a comma-separated list of environments
 ```
+
+### test
+```
+slate test
+```
+
+Uses the [@shopify/theme-lint](https://github.com/Shopify/theme-lint) package to run translations tests on your locales found in the `/src/locales` folder. The package checks for untranslated keys inside of your Liquid templates, missing translation keys in specific locale files, and translation key HTML validity.
 
 ### watch
 ```


### PR DESCRIPTION
Adds the `slate test` command documentation to the README. This won't be merged before https://github.com/Shopify/slate-tools/pull/55 gets merged into `slate-tools`.


### Checklist
- [x] I have updated the documentation in the [README file](https://github.com/Shopify/slate-cli/blob/master/README.md) to
reflect these changes, if applicable.

Considerations:
- [x] These changes will require the [public Slate docs](https://shopify.github.io/slate/) to be updated.  See the [Shopify/slate repo](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) for notes on updating docs, if applicable.
