### PR TITLE
Add install deps with yarn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,36 @@ npm install @shopify/slate --global
 
 Command                      | Usage
 ---                          | ---
-[theme](#theme)              | `slate theme [name]`
-[migrate](#migrate)          | `slate migrate`
+[theme](#theme)              | `slate theme [name] [--options]`
+[migrate](#migrate)          | `slate migrate [--options]`
 [help](#help)                | `slate -h`
 [version](#version)          | `slate -v`
 
 ### theme
 ```
-slate theme [name]
+slate theme [name] [--options]
 ```
 
 Generates a theme with build tools. The name argument is required and you will be prompted to enter it if it's not provided.
 
+#### options
+```
+--yarn  installs theme dependencies with yarn instead of npm
+```
+
 ### migrate
 ```
-slate migrate
+slate migrate [--options]
 ```
 
 Converts an existing theme to work with Slate. Run this command from your project root to install dependencies and restructure your theme files into a `src/` directory.  Empty `icons/`, `styles/` and `scripts/` folders will also be created.
 
 Create `config.yml` in your root using [this sample file](https://github.com/Shopify/slate/blob/master/config-sample.yml), then use [theme commands](#theme-commands) to start developing.
+
+#### options
+```
+--yarn  installs theme dependencies with yarn instead of npm
+```
 
 ### help
 ```

--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -10,7 +10,8 @@ export default function(program) {
   program
     .command('migrate')
     .description('Converts an existing theme to work with Slate.')
-    .action(async () => {
+    .option('--yarn', 'installs theme dependencies with yarn instead of npm')
+    .action(async (options = {}) => {
       const workingDirectory = process.cwd();
       const answers = await prompt({
         type: 'confirm',
@@ -83,7 +84,15 @@ export default function(program) {
         console.log('  Installing Slate dependencies...');
         console.log('');
 
-        await startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {cwd: workingDirectory});
+        if (options.yarn) {
+          await startProcess('yarn', ['add', '@shopify/slate-tools', '--dev', '--exact'], {
+            cwd: workingDirectory,
+          });
+        } else {
+          await startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
+            cwd: workingDirectory,
+          });
+        }
 
         console.log('');
         console.log(`  ${green(figures.tick)} Slate dependencies installed`);

--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -12,7 +12,8 @@ export default function(program) {
     .command('theme [name]')
     .alias('t')
     .description('Generates a new theme directory containing Slate\'s theme boilerplate.')
-    .action(async (name) => {
+    .option('--yarn', 'installs theme dependencies with yarn instead of npm')
+    .action(async (name, options = {}) => {
       let dirName = name;
 
       if (!dirName) {
@@ -63,9 +64,15 @@ export default function(program) {
 
           writePackageJsonSync(pkg, dirName);
 
-          return startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
-            cwd: root,
-          });
+          if (options.yarn) {
+            return startProcess('yarn', ['add', '@shopify/slate-tools', '--dev', '--exact'], {
+              cwd: root,
+            });
+          } else {
+            return startProcess('npm', ['install', '@shopify/slate-tools', '--save-dev', '--save-exact'], {
+              cwd: root,
+            });
+          }
         })
         .then(() => {
           console.log(`  ${green(figures.tick)} devDependencies installed`);


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

https://github.com/Shopify/slate-cli/issues/123

This PR adds an option to both `migrate` and `theme` to install deps with `yarn` rather than `npm`. I think keeping `npm` as the default makes sense... `yarn` would be another dep to require before installing slate.


### Checklist
For contributors:
- [x] I have updated the documentation in the [README file](https://github.com/Shopify/slate-cli/blob/master/README.md) to
reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

Considerations:
- [x] These changes will require the [public Slate docs](https://shopify.github.io/slate/) to be updated.  See the [Shopify/slate repo](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) for notes on updating docs, if applicable.
