### PR TITLE
Generate config.yml during migration if none available

### DIFF
--- a/src/commands/migrate.js
+++ b/src/commands/migrate.js
@@ -4,7 +4,7 @@ import {join} from 'path';
 import {prompt} from 'inquirer';
 import {green, red, yellow} from 'chalk';
 import figures from 'figures';
-import {startProcess, writePackageJsonSync, move, isShopifyTheme, isShopifyThemeWhitelistedDir} from '../utils';
+import {downloadFromUrl, startProcess, writePackageJsonSync, move, isShopifyTheme, isShopifyThemeWhitelistedDir} from '../utils';
 
 export default function(program) {
   program
@@ -90,8 +90,12 @@ export default function(program) {
         console.log('');
 
         if (!existsSync(configYml)) {
-          console.error(yellow('  Your theme is missing config.yml in the root directory. Please add before using Slate commands'));
-          console.error(yellow('  Example config.yml here: https://github.com/Shopify/slate/blob/master/config-sample.yml'));
+          const configUrl = 'https://raw.githubusercontent.com/Shopify/slate/master/config-sample.yml';
+
+          await downloadFromUrl(configUrl, join(workingDirectory, 'config.yml'));
+
+          console.error(`  ${green(figures.tick)} Configuration file generated`);
+          console.error(yellow('  Your theme was missing config.yml in the root directory. Please open and edit it before using Slate commands'));
           console.log('');
         }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,20 +15,20 @@ import mv from 'mv';
  */
 export function downloadFromUrl(source, target) {
   return new Promise((resolve, reject) => {
-    const themeZipFile = createWriteStream(target);
+    const targetFile = createWriteStream(target);
 
-    themeZipFile.on('open', () => {
+    targetFile.on('open', () => {
       get(source, (response) => {
-        response.pipe(themeZipFile);
+        response.pipe(targetFile);
       });
     });
 
-    themeZipFile.on('error', (err) => {
+    targetFile.on('error', (err) => {
       unlinkSync(target);
       reject(err);
     });
 
-    themeZipFile.on('close', () => {
+    targetFile.on('close', () => {
       resolve(target);
     });
   });


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Fixes #122.

When running `slate migrate`, instead of telling a user to go to a URL, adding it to the root directory and then editing it - let's do 2 out of those 3 things automatically.

You should end up with this:

![image](https://cloud.githubusercontent.com/assets/991693/26060369/dd62cb8e-3952-11e7-9ef6-e037eee7c5f4.png)

### Checklist
For contributors:
- [ ] I have updated the documentation in the [README file](https://github.com/Shopify/slate-cli/blob/master/README.md) to
reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

Considerations:
- [x] These changes will require the [public Slate docs](https://shopify.github.io/slate/) to be updated.  See the [Shopify/slate repo](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) for notes on updating docs, if applicable.

cc @cshold @t-kelly 