### PR TITLE
Add slate help command

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,0 +1,7 @@
+export default function(program) {
+  program
+    .command('help')
+    .action(() => {
+      program.help();
+    });
+}

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,6 +1,8 @@
 export default function(program) {
   program
     .command('help')
+    .alias('h')
+    .description('Output usage information')
     .action(() => {
       program.help();
     });

--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,7 @@ updateNotifier({
 }).notify();
 
 // Global commands
+require('./commands/help').default(program);
 require('./commands/theme').default(program);
 require('./commands/migrate').default(program);
 require('./commands/version').default(program);


### PR DESCRIPTION
Fixes #107.

Adds `slate help` as a generic command (so we don't need to run `slate -h` or `slate --help` - similar to what we're doing with `slate version`.

### Checklist
For contributors:
- [ ] I have updated the documentation in the [README file](https://github.com/Shopify/slate-cli/blob/master/README.md) to
reflect these changes, if applicable.

For maintainers:
- [x] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

Considerations:
- [x] These changes will require the [public Slate docs](https://shopify.github.io/slate/) to be updated.  See the [Shopify/slate repo](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) for notes on updating docs, if applicable.
