### PR TITLE
Update directory exists error message

### DIFF
--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -42,7 +42,7 @@ export default function(program) {
 
       if (existsSync(root)) {
         console.log('');
-        console.error(red(`  ${figures.cross} ${root} is not an empty directory`));
+        console.error(red(`  ${figures.cross} The ${root} directory already exists`));
         console.log('');
         return null;
       }


### PR DESCRIPTION
The original error message of `is not an empty directory` did not really make sense as the directory itself could be empty but exist.