### PR TITLE
rename sample files once unzipped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2863 @@
+{
+  "name": "@shopify/slate",
+  "version": "0.10.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@shopify/commander": {
+      "version": "https://registry.npmjs.org/@shopify/commander/-/commander-2.9.2.tgz",
+      "integrity": "sha1-9L3IrloqRepxt/a3C1R2wGhYBKw="
+    },
+    "acorn": {
+      "version": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+      "integrity": "sha1-F6jWp6bE71OLgU7Jq6wneSk78wo=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+      "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
+      "dev": true
+    },
+    "ajv-keywords": {
+      "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "ansi-align": {
+      "version": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro="
+    },
+    "ansi-escapes": {
+      "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+    },
+    "ansi-regex": {
+      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "anymatch": {
+      "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "dev": true,
+      "optional": true
+    },
+    "argparse": {
+      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true
+    },
+    "arr-diff": {
+      "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "optional": true
+    },
+    "arr-flatten": {
+      "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+      "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+      "dev": true,
+      "optional": true
+    },
+    "array-differ": {
+      "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true,
+      "optional": true
+    },
+    "arrify": {
+      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true,
+      "optional": true
+    },
+    "babel-cli": {
+      "version": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.18.0.tgz",
+      "integrity": "sha1-khF/NBrdnerZD2+n0Kl8DMCOwYY=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true
+        }
+      }
+    },
+    "babel-code-frame": {
+      "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "dev": true
+    },
+    "babel-core": {
+      "version": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
+      "integrity": "sha1-2LsU3WmG+k81ZqJs7aOWT6DgTls=",
+      "dev": true
+    },
+    "babel-eslint": {
+      "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.0.0.tgz",
+      "integrity": "sha1-VOUbQDP1SsgTJuzqTGRqd5k1GW0=",
+      "dev": true
+    },
+    "babel-generator": {
+      "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.0.tgz",
+      "integrity": "sha1-66JwqMxM5uCaYb5DRl18YsH4fFY=",
+      "dev": true
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.22.0.tgz",
+      "integrity": "sha1-1/W8JhJ1lBrGKs/E4g2s+4o/6VI=",
+      "dev": true
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz",
+      "integrity": "sha1-Kd9WvhRNgb3qwIJiv6QdLF6Rzc0=",
+      "dev": true
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.23.0.tgz",
+      "integrity": "sha1-1T/IyZbgvFbQ3g/EzFWnE4OV6ks=",
+      "dev": true
+    },
+    "babel-helper-call-delegate": {
+      "version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
+      "integrity": "sha1-EZkhtWEg8X6drj90tPXMe8wbN+8=",
+      "dev": true
+    },
+    "babel-helper-define-map": {
+      "version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz",
+      "integrity": "sha1-FET5YMlpHWmiztaiBTFfj9AIBOc=",
+      "dev": true
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz",
+      "integrity": "sha1-yXv3bu0+C65ASBIfK52uGk59BHg=",
+      "dev": true
+    },
+    "babel-helper-explode-class": {
+      "version": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.22.0.tgz",
+      "integrity": "sha1-ZGMEkkqmOIpRaEO6fxhV743+tps=",
+      "dev": true
+    },
+    "babel-helper-function-name": {
+      "version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
+      "integrity": "sha1-JXQtZxdciQPb5LbLnZ4fy43PI6Y=",
+      "dev": true
+    },
+    "babel-helper-get-function-arity": {
+      "version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
+      "integrity": "sha1-C+tGStadxzR0EKxq3p8DpQY09c4=",
+      "dev": true
+    },
+    "babel-helper-hoist-variables": {
+      "version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
+      "integrity": "sha1-Pqy/cx2AcFhF3S6XGPYAz7m0unI=",
+      "dev": true
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz",
+      "integrity": "sha1-8+5+7TVbQoITizPQK3g2nkcGIvU=",
+      "dev": true
+    },
+    "babel-helper-regex": {
+      "version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+      "integrity": "sha1-efUyvhZHsfDuNHS19cPaWAAdJH0=",
+      "dev": true
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.22.0.tgz",
+      "integrity": "sha1-IYaucyeO0DuLFc7QiWCdqYEFM4M=",
+      "dev": true
+    },
+    "babel-helper-replace-supers": {
+      "version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz",
+      "integrity": "sha1-7q+K2bWOxDN8qUIjus3KH42bS/0=",
+      "dev": true
+    },
+    "babel-helpers": {
+      "version": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.23.0.tgz",
+      "integrity": "sha1-T48uCS0LaogIpL3nnCfx4uzw2ZI=",
+      "dev": true
+    },
+    "babel-messages": {
+      "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true
+    },
+    "babel-plugin-add-header-comment": {
+      "version": "https://registry.npmjs.org/babel-plugin-add-header-comment/-/babel-plugin-add-header-comment-1.0.3.tgz",
+      "integrity": "sha1-URxJAQYmQNWkgLSsPt1pRBlYUOw=",
+      "dev": true
+    },
+    "babel-plugin-add-shopify-header": {
+      "version": "https://registry.npmjs.org/babel-plugin-add-shopify-header/-/babel-plugin-add-shopify-header-1.0.6.tgz",
+      "integrity": "sha1-iuU77x1HSyiycsj8p7a5slSV29w=",
+      "dev": true
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+      "dev": true
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.22.0.tgz",
+      "integrity": "sha1-pyCpgVOnWW8gQJnNVAn0s8Bbq0Y=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
+      "integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
+      "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.23.0.tgz",
+      "integrity": "sha1-GHt0fuQEOZATVjyZPbA480dUrDs=",
+      "dev": true
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.22.0.tgz",
+      "integrity": "sha1-wDY1snojsjtyJPSSMsI3pzmI0nw=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz",
+      "integrity": "sha1-5IiVzws3W+FIzXyIebQicHoFO1E=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz",
+      "integrity": "sha1-SbU/MmICov0bO7ql4u3YpPeGQ8E=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
+      "integrity": "sha1-fDg+lim7pIIMEbBCW91ikPfwV+c=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
+      "integrity": "sha1-ZyOXAxwhYQ1y3Su7C6n7Ynfhw2s=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
+      "integrity": "sha1-9fzIsJCT+aI8dqw9njksPsS3cQQ=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.0.tgz",
+      "integrity": "sha1-oZEfubfsfgWkOmPFmVAHVXvPai4=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz",
+      "integrity": "sha1-6SGu+3LCzCbLA9EHYmFWQTIiE08=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.23.0.tgz",
+      "integrity": "sha1-rjRpIn/6w5sDENkP7HO/3E9jF7A=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.0.tgz",
+      "integrity": "sha1-/V+mNSHK6NJzknw5WK/XwGdzNFA=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
+      "integrity": "sha1-2qYOEUoELqdp3VP+Uo/IIxHrmPw=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz",
+      "integrity": "sha1-OiqrtwyK+UXVzjhvGkJQYlqDrjs=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
+      "integrity": "sha1-i6d24K/6pgv/IekhQDuKZSov9yM=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
+      "integrity": "sha1-qzFoKehm7j9LnrlpOXV9GaW8RZM=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
+      "integrity": "sha1-jZzCfn7h3s/mVFT7mGRSoEphPSA=",
+      "dev": true
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.22.0.tgz",
+      "integrity": "sha1-1XyDNSgZGOVO8FMRjObrEIRoCE0=",
+      "dev": true
+    },
+    "babel-plugin-transform-export-extensions": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+      "dev": true
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true
+    },
+    "babel-plugin-transform-inline-environment-variables": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-6.8.0.tgz",
+      "integrity": "sha1-/JHdCBJ9xsKr39FyGxHpYCppuhA=",
+      "dev": true
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
+      "integrity": "sha1-Q5iRDDWEQdxM7xh4cmTQQS7Tazc=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.23.0.tgz",
+      "integrity": "sha1-I+iS9/LnWWeOteREao+OlOgbNHA=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
+      "integrity": "sha1-ZXQFk6MZxEUiFXU41pC4QJRhfqY=",
+      "dev": true
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
+      "integrity": "sha1-4AjfATQP3IfpWdplmRt+BZcMjHw=",
+      "dev": true
+    },
+    "babel-polyfill": {
+      "version": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
+      "integrity": "sha1-LUUCHfh+JqN0ttTRqcZZZNF/JCI="
+    },
+    "babel-preset-es2015": {
+      "version": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.0.tgz",
+      "integrity": "sha1-wWLWixkyaW4DbNMRDcHM0wPSZzo=",
+      "dev": true
+    },
+    "babel-preset-es2016": {
+      "version": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.22.0.tgz",
+      "integrity": "sha1-sGGqo5g9QMn7rPo3Q7XfN/M2FWw=",
+      "dev": true
+    },
+    "babel-preset-es2017": {
+      "version": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.22.0.tgz",
+      "integrity": "sha1-3i+dpaMMUNKT+1SguhXW3cVz8PI=",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-transform-async-to-generator": {
+          "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz",
+          "integrity": "sha1-GUtpOOwZWtNu/EwzqXGs8A2M014=",
+          "dev": true
+        }
+      }
+    },
+    "babel-preset-flow": {
+      "version": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true
+    },
+    "babel-preset-react": {
+      "version": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.23.0.tgz",
+      "integrity": "sha1-63zuTemKP5RQLChWUzLamBlFUZU=",
+      "dev": true
+    },
+    "babel-preset-shopify": {
+      "version": "https://registry.npmjs.org/babel-preset-shopify/-/babel-preset-shopify-15.0.1.tgz",
+      "integrity": "sha1-kLKUfODO2hFe7h4YHTTe/i2nEC8=",
+      "dev": true
+    },
+    "babel-preset-stage-2": {
+      "version": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.22.0.tgz",
+      "integrity": "sha1-zNVl8ZwkXK3jlLISFt9wSnOyfAc=",
+      "dev": true
+    },
+    "babel-preset-stage-3": {
+      "version": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.22.0.tgz",
+      "integrity": "sha1-pOkrus50Vvr99lHXp2V+4LvKnC4=",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-transform-async-to-generator": {
+          "version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz",
+          "integrity": "sha1-GUtpOOwZWtNu/EwzqXGs8A2M014=",
+          "dev": true
+        }
+      }
+    },
+    "babel-register": {
+      "version": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
+      "integrity": "sha1-iS4uA4ZQeN2QrSxxURHsREmzKmg=",
+      "dev": true
+    },
+    "babel-runtime": {
+      "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
+          "integrity": "sha1-jENnqQS1HqYqkIrDEL+Z/5CoKj4="
+        }
+      }
+    },
+    "babel-template": {
+      "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+      "integrity": "sha1-BNTycK27OqcEqBQ64m+qUpI45jg=",
+      "dev": true
+    },
+    "babel-traverse": {
+      "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+      "integrity": "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g=",
+      "dev": true
+    },
+    "babel-types": {
+      "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+      "integrity": "sha1-uxcXnXU4utOM0MnhFdNA935+ms8=",
+      "dev": true
+    },
+    "babylon": {
+      "version": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
+      "integrity": "sha1-MMWiL0gZeKnn+M399JaxHZS0BNM=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+    },
+    "binary": {
+      "version": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk="
+    },
+    "binary-extensions": {
+      "version": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
+      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "dev": true,
+      "optional": true
+    },
+    "boxen": {
+      "version": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY="
+    },
+    "brace-expansion": {
+      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk="
+    },
+    "braces": {
+      "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "optional": true
+    },
+    "buf-compare": {
+      "version": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha1-/vKNqLgROgoNtEMLC2Rntpcws0o=",
+      "dev": true
+    },
+    "buffer-shims": {
+      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "buffers": {
+      "version": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+    },
+    "builtin-modules": {
+      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "capture-stack-trace": {
+      "version": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+    },
+    "chainsaw": {
+      "version": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg="
+    },
+    "chalk": {
+      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+    },
+    "chokidar": {
+      "version": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+      "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
+      "dev": true,
+      "optional": true
+    },
+    "circular-json": {
+      "version": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+    },
+    "cli-cursor": {
+      "version": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
+    },
+    "cli-width": {
+      "version": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+    },
+    "co": {
+      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "commander": {
+      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+    },
+    "configstore": {
+      "version": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        }
+      }
+    },
+    "contains-path": {
+      "version": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz",
+      "integrity": "sha1-49rRlb9hv+E6ejxz6YduwUoCaPM=",
+      "dev": true
+    },
+    "core-assert": {
+      "version": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+    },
+    "core-util-is": {
+      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-error-class": {
+      "version": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y="
+    },
+    "cross-spawn": {
+      "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.0.1.tgz",
+      "integrity": "sha1-o7uzAtsil8vqPATt82lB9GE6o5k="
+    },
+    "d": {
+      "version": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true
+    },
+    "damerau-levenshtein": {
+      "version": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.3.tgz",
+      "integrity": "sha1-rk9M4LYqyuEP9joBuwj2UvUhOvI=",
+      "dev": true
+    },
+    "debug": {
+      "version": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w="
+    },
+    "deep-extend": {
+      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+      "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+    },
+    "deep-is": {
+      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deep-strict-equal": {
+      "version": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
+      "dev": true
+    },
+    "del": {
+      "version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true
+    },
+    "dot-prop": {
+      "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc="
+    },
+    "duplexer2": {
+      "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME="
+    },
+    "enhance-visitors": {
+      "version": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+      "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+    },
+    "es5-ext": {
+      "version": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.14.tgz",
+      "integrity": "sha1-YlvJq5ysD2+53CcVJYI9GACz02A=",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "dev": true
+    },
+    "es6-map": {
+      "version": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true
+    },
+    "es6-set": {
+      "version": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true
+    },
+    "es6-symbol": {
+      "version": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true
+    },
+    "es6-weak-map": {
+      "version": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escope": {
+      "version": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "https://registry.npmjs.org/eslint/-/eslint-3.10.2.tgz",
+      "integrity": "sha1-yaEOi/bp1lZRIEd4xQM0Hx6sPOc=",
+      "dev": true,
+      "dependencies": {
+        "figures": {
+          "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "dev": true
+        },
+        "run-async": {
+          "version": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+          "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "user-home": {
+          "version": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
+      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+      "dev": true
+    },
+    "eslint-module-utils": {
+      "version": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-1.0.0.tgz",
+      "integrity": "sha1-xKV/06U+/YQmzC1VUKraubvQX9A=",
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-ava": {
+      "version": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-3.1.1.tgz",
+      "integrity": "sha1-/c8a2WBYZ2Oa4AB9WBAO5Apt4l0=",
+      "dev": true
+    },
+    "eslint-plugin-babel": {
+      "version": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz",
+      "integrity": "sha1-L0lK7c9vSqTnW5FVmAg3vB+94ZM=",
+      "dev": true
+    },
+    "eslint-plugin-chai-expect": {
+      "version": "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-1.1.1.tgz",
+      "integrity": "sha1-zWQLizjPbDq8w3hnO3sXO5ndxwo=",
+      "dev": true
+    },
+    "eslint-plugin-flowtype": {
+      "version": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.20.0.tgz",
+      "integrity": "sha1-abkFdhdO5qMFNix3dyCCXn25Rks=",
+      "dev": true
+    },
+    "eslint-plugin-import": {
+      "version": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.0.1.tgz",
+      "integrity": "sha1-3P6WNX1Haz+CJXDULCm+xm9dnFw=",
+      "dev": true,
+      "dependencies": {
+        "doctrine": {
+          "version": "https://registry.npmjs.org/doctrine/-/doctrine-1.3.0.tgz",
+          "integrity": "sha1-E+dWgrVVGEJCdvfBc3g0Vu+RPSY=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz",
+      "integrity": "sha1-TjXLcbin23AqxBXIBuuOjZ6mxl0=",
+      "dev": true
+    },
+    "eslint-plugin-lodash": {
+      "version": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-1.10.3.tgz",
+      "integrity": "sha1-o0HjOGtutOS3rdz0PDp/lE84VR0=",
+      "dev": true
+    },
+    "eslint-plugin-mocha": {
+      "version": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.7.0.tgz",
+      "integrity": "sha1-aSYjYvTsaa5YSZCIJPMluNRl5/M=",
+      "dev": true
+    },
+    "eslint-plugin-node": {
+      "version": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-3.0.4.tgz",
+      "integrity": "sha1-4akfWA7AgeTtqSdyMiEDIw+feig=",
+      "dev": true
+    },
+    "eslint-plugin-promise": {
+      "version": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.0.0.tgz",
+      "integrity": "sha1-FShjXQFg80hOQlzOIWnLdM7AGGo=",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.4.1.tgz",
+      "integrity": "sha1-fRqt50fbFYkvce7h/qSt35e8+is=",
+      "dev": true
+    },
+    "eslint-plugin-shopify": {
+      "version": "https://registry.npmjs.org/eslint-plugin-shopify/-/eslint-plugin-shopify-15.1.0.tgz",
+      "integrity": "sha1-Bp6+r9nH/Ku93GWj8DYXc2g/EUg=",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-node": {
+          "version": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-2.1.4.tgz",
+          "integrity": "sha1-YKBNcdlRLXKAGqxaGELKdEzY7sY=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-sort-class-members": {
+      "version": "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.1.1.tgz",
+      "integrity": "sha1-3tuzAFT87RpVqdRDuyuEKgz8lfE=",
+      "dev": true
+    },
+    "espree": {
+      "version": "https://registry.npmjs.org/espree/-/espree-3.4.0.tgz",
+      "integrity": "sha1-QWVvpWKOBCh4Al70Z+ePEly4bh0=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "dev": true
+    },
+    "espurify": {
+      "version": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
+      "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "dev": true,
+      "dependencies": {
+        "estraverse": {
+          "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "expand-brackets": {
+      "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "optional": true
+    },
+    "expand-range": {
+      "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "optional": true
+    },
+    "extend": {
+      "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+    },
+    "external-editor": {
+      "version": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs="
+    },
+    "extglob": {
+      "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "optional": true
+    },
+    "fast-levenshtein": {
+      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI="
+    },
+    "file-entry-cache": {
+      "version": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true
+    },
+    "filename-regex": {
+      "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+      "dev": true,
+      "optional": true
+    },
+    "fill-range": {
+      "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "dev": true,
+      "optional": true
+    },
+    "filled-array": {
+      "version": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
+    },
+    "find-root": {
+      "version": "https://registry.npmjs.org/find-root/-/find-root-1.0.0.tgz",
+      "integrity": "sha1-li/yEaqyXGUg/u641ih/j26VgHo="
+    },
+    "find-up": {
+      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
+      }
+    },
+    "for-in": {
+      "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
+      "optional": true
+    },
+    "for-own": {
+      "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "optional": true
+    },
+    "fs-readdir-recursive": {
+      "version": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
+      "integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+          "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
+          "dev": true,
+          "optional": true
+        },
+        "asn1": {
+          "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "dev": true,
+          "optional": true
+        },
+        "block-stream": {
+          "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+          "dev": true
+        },
+        "boom": {
+          "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+          "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
+          "dev": true
+        },
+        "buffer-shims": {
+          "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+          "dev": true
+        },
+        "caseless": {
+          "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "dev": true
+        },
+        "commander": {
+          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "optional": true
+        },
+        "dashdash": {
+          "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+          "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+          "dev": true
+        },
+        "delegates": {
+          "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "dev": true,
+          "optional": true
+        },
+        "escape-string-regexp": {
+          "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+          "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
+          "dev": true,
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "dev": true
+        },
+        "fstream": {
+          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
+          "dev": true
+        },
+        "fstream-ignore": {
+          "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+          "integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
+          "dev": true,
+          "optional": true
+        },
+        "generate-function": {
+          "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+          "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+          "dev": true,
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+          "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+          "dev": true,
+          "optional": true
+        },
+        "getpass": {
+          "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "graceful-readlink": {
+          "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+          "dev": true,
+          "optional": true
+        },
+        "has-ansi": {
+          "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "dev": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "optional": true
+        },
+        "hoek": {
+          "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true
+        },
+        "inflight": {
+          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "dev": true
+        },
+        "inherits": {
+          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ini": {
+          "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true
+        },
+        "is-my-json-valid": {
+          "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+          "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+          "dev": true,
+          "optional": true
+        },
+        "is-property": {
+          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+          "dev": true,
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isstream": {
+          "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+          "dev": true,
+          "optional": true
+        },
+        "jsbn": {
+          "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+          "dev": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true,
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+          "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+          "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+          "dev": true,
+          "optional": true
+        },
+        "mime-db": {
+          "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+          "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8=",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+          "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true
+        },
+        "ms": {
+          "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
+          "integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
+          "dev": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "optional": true
+        },
+        "npmlog": {
+          "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+          "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
+          "dev": true,
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true,
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
+          "integrity": "sha1-kYwLO802Z5dyuvE1say0wWUe150=",
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+          "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+          "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
+          "dev": true,
+          "optional": true
+        },
+        "request": {
+          "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+          "dev": true
+        },
+        "semver": {
+          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "optional": true
+        },
+        "sshpk": {
+          "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+          "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true
+        },
+        "stringstream": {
+          "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "dev": true
+        },
+        "tar-pack": {
+          "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
+          "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "dev": true,
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+          "dev": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
+          "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
+          "dev": true,
+          "optional": true
+        },
+        "wrappy": {
+          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg="
+    },
+    "function-bind": {
+      "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true
+    },
+    "get-project-version": {
+      "version": "https://registry.npmjs.org/get-project-version/-/get-project-version-1.0.3.tgz",
+      "integrity": "sha1-3EK5xDK3SAjObQhYlpg2CAKO/qE=",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "git-rev-sync": {
+      "version": "git://github.com/mikkoh/git-rev-sync.git#e576ceb4992b995e208b7ae0c859305dcb2a5ebf",
+      "integrity": "sha1-lleD91fHnwu0EAjgCf3mZAlwLsg=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+          "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
+          "dev": true
+        }
+      }
+    },
+    "glob": {
+      "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI="
+    },
+    "glob-base": {
+      "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "optional": true
+    },
+    "glob-parent": {
+      "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true
+    },
+    "globals": {
+      "version": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
+      "integrity": "sha1-Y+kDZYFx7C2fUbHTHeXiuNwB+4A=",
+      "dev": true
+    },
+    "globby": {
+      "version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        }
+      }
+    },
+    "got": {
+      "version": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU="
+    },
+    "graceful-fs": {
+      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg="
+    },
+    "graceful-readlink": {
+      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
+    "has": {
+      "version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+    },
+    "home-or-tmp": {
+      "version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "https://registry.npmjs.org/ignore/-/ignore-3.2.6.tgz",
+      "integrity": "sha1-JujaBkS+C7TLOVFvbHnw4PT/5Iw=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "inflight": {
+      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+    },
+    "inherits": {
+      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+    },
+    "inquirer": {
+      "version": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+      "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+      "dependencies": {
+        "figures": {
+          "version": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
+        }
+      }
+    },
+    "interpret": {
+      "version": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+      "integrity": "sha1-1Xn7f2k7hYAElHrzn6DbSfeVYCw=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-binary-path": {
+      "version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "optional": true
+    },
+    "is-buffer": {
+      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "is-dotfile": {
+      "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+      "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+      "dev": true,
+      "optional": true
+    },
+    "is-equal-shallow": {
+      "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "optional": true
+    },
+    "is-error": {
+      "version": "https://registry.npmjs.org/is-error/-/is-error-2.2.1.tgz",
+      "integrity": "sha1-aEqW2EB2V3yY9M20DG0mpRI78Zw=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "optional": true
+    },
+    "is-extglob": {
+      "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko="
+    },
+    "is-fullwidth-code-point": {
+      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+    },
+    "is-glob": {
+      "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true
+    },
+    "is-npm": {
+      "version": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+    },
+    "is-number": {
+      "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-path-cwd": {
+      "version": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "dev": true
+    },
+    "is-posix-bracket": {
+      "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true,
+      "optional": true
+    },
+    "is-primitive": {
+      "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-property": {
+      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-resolvable": {
+      "version": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
+    "is-stream": {
+      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isarray": {
+      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
+    },
+    "isobject": {
+      "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "optional": true
+    },
+    "js-tokens": {
+      "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.2.tgz",
+      "integrity": "sha1-AtPiwPa+qyAkjUEsNSIDgn14ZyE=",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true
+    },
+    "json5": {
+      "version": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz",
+      "integrity": "sha1-Wv44ho9WvIzHrq7wEAuox1vRJZE=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
+      "dev": true
+    },
+    "latest-version": {
+      "version": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos="
+    },
+    "lazy-req": {
+      "version": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
+    },
+    "levn": {
+      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash.cond": {
+      "version": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "dev": true
+    },
+    "lodash.pickby": {
+      "version": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+    },
+    "lru-cache": {
+      "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4="
+    },
+    "match-stream": {
+      "version": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+        }
+      }
+    },
+    "merge": {
+      "version": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "optional": true
+    },
+    "minimatch": {
+      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q="
+    },
+    "minimist": {
+      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM="
+    },
+    "ms": {
+      "version": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+    },
+    "multimatch": {
+      "version": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+    },
+    "mv": {
+      "version": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "dependencies": {
+        "rimraf": {
+          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto="
+        }
+      }
+    },
+    "nan": {
+      "version": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+      "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
+      "dev": true,
+      "optional": true
+    },
+    "natives": {
+      "version": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
+      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE="
+    },
+    "natural-compare": {
+      "version": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "ncp": {
+      "version": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+    },
+    "node-status-codes": {
+      "version": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+    },
+    "normalize-path": {
+      "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+      "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+      "dev": true,
+      "optional": true
+    },
+    "number-is-nan": {
+      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object.omit": {
+      "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "optional": true
+    },
+    "once": {
+      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+    },
+    "onetime": {
+      "version": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "optionator": {
+      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-shim": {
+      "version": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
+    },
+    "os-tmpdir": {
+      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ="
+    },
+    "output-file-sync": {
+      "version": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        }
+      }
+    },
+    "over": {
+      "version": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
+      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
+    },
+    "package-json": {
+      "version": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs="
+    },
+    "parse-glob": {
+      "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "optional": true
+    },
+    "parse-json": {
+      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+    },
+    "path-exists": {
+      "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "pify": {
+      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+    },
+    "pkg-dir": {
+      "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "dev": true
+    },
+    "pkg-up": {
+      "version": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
+      "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "preserve": {
+      "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true,
+      "optional": true
+    },
+    "private": {
+      "version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "pullstream": {
+      "version": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+        }
+      }
+    },
+    "ramda": {
+      "version": "https://registry.npmjs.org/ramda/-/ramda-0.22.1.tgz",
+      "integrity": "sha1-Ax2gw99BfFszyWI0dX6zcDPzag4=",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+      "dev": true,
+      "optional": true
+    },
+    "rc": {
+      "version": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+      "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
+      "dependencies": {
+        "minimist": {
+          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "read-all-stream": {
+      "version": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po="
+    },
+    "readable-stream": {
+      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+      "integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY="
+    },
+    "readdirp": {
+      "version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "readline2": {
+      "version": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "dependencies": {
+        "mute-stream": {
+          "version": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        }
+      }
+    },
+    "rechoir": {
+      "version": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true
+    },
+    "regenerate": {
+      "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+      "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
+    },
+    "regenerator-transform": {
+      "version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
+      "integrity": "sha1-D4i7K8A5Mt23trcxLmgHjwECbWw=",
+      "dev": true
+    },
+    "regex-cache": {
+      "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "dev": true,
+      "optional": true
+    },
+    "regexpu-core": {
+      "version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true
+    },
+    "registry-auth-token": {
+      "version": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
+      "integrity": "sha1-mXwIJW4MeZmDe5DpRNs52KeQJ2s="
+    },
+    "registry-url": {
+      "version": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI="
+    },
+    "regjsgen": {
+      "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "dependencies": {
+        "jsesc": {
+          "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "repeat-element": {
+      "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "optional": true
+    },
+    "repeating": {
+      "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo="
+    },
+    "req-all": {
+      "version": "https://registry.npmjs.org/req-all/-/req-all-0.1.0.tgz",
+      "integrity": "sha1-EwBR4qzligLqy/ydRIV3pzapJzo=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
+      "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
+    },
+    "rimraf": {
+      "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg="
+        }
+      }
+    },
+    "run-async": {
+      "version": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA="
+    },
+    "rx": {
+      "version": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    },
+    "rx-lite": {
+      "version": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "semver": {
+      "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "semver-diff": {
+      "version": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY="
+    },
+    "set-immediate-shim": {
+      "version": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true,
+      "optional": true
+    },
+    "setimmediate": {
+      "version": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "shebang-command": {
+      "version": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
+    },
+    "shebang-regex": {
+      "version": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shelljs": {
+      "version": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.4.tgz",
+      "integrity": "sha1-uPBLOnTd+v6iKs+Y4L5F3tU9Wcg=",
+      "dev": true,
+      "dependencies": {
+        "glob": {
+          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true
+        }
+      }
+    },
+    "slash": {
+      "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "slice-stream": {
+      "version": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+        }
+      }
+    },
+    "slide": {
+      "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "source-map": {
+      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.13.tgz",
+      "integrity": "sha1-l4Lm9960JNXxczJ6GHnrRkU73NQ=",
+      "dev": true
+    },
+    "spawn-sync": {
+      "version": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY="
+    },
+    "sprintf-js": {
+      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "string-width": {
+      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+    },
+    "strip-ansi": {
+      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+    },
+    "strip-bom": {
+      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "table": {
+      "version": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "timed-out": {
+      "version": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+    },
+    "tmp": {
+      "version": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA="
+    },
+    "to-fast-properties": {
+      "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+      "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA=",
+      "dev": true
+    },
+    "traverse": {
+      "version": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+    },
+    "trim-right": {
+      "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tryit": {
+      "version": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "unzip-response": {
+      "version": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+    },
+    "unzip2": {
+      "version": "https://registry.npmjs.org/unzip2/-/unzip2-0.2.5.tgz",
+      "integrity": "sha1-TveleaeMFcUfVQ9qBT2xlBSciZI=",
+      "dependencies": {
+        "isarray": {
+          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw="
+        }
+      }
+    },
+    "update-notifier": {
+      "version": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.2.tgz",
+      "integrity": "sha1-J8kFGRltwVAVvgKjTqUphv6riHc="
+    },
+    "url-parse-lax": {
+      "version": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+    },
+    "user-home": {
+      "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+    },
+    "v8flags": {
+      "version": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.11.tgz",
+      "integrity": "sha1-vKjzDw1tYGEswsAGQeaWLUKuaIE=",
+      "dev": true
+    },
+    "which": {
+      "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI="
+    },
+    "widest-line": {
+      "version": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw="
+    },
+    "wordwrap": {
+      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
+      "integrity": "sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        }
+      }
+    },
+    "xdg-basedir": {
+      "version": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I="
+    },
+    "xtend": {
+      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1836,7 +1836,6 @@
     },
     "git-rev-sync": {
       "version": "git://github.com/mikkoh/git-rev-sync.git#e576ceb4992b995e208b7ae0c859305dcb2a5ebf",
-      "integrity": "sha1-lleD91fHnwu0EAjgCf3mZAlwLsg=",
       "dev": true,
       "dependencies": {
         "graceful-fs": {

--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -5,7 +5,7 @@ import {prompt} from 'inquirer';
 import rimraf from 'rimraf';
 import {green, red} from 'chalk';
 import figures from 'figures';
-import {downloadFromUrl, unzip, startProcess, writePackageJsonSync} from '../utils';
+import {downloadFromUrl, unzip, renameFile, startProcess, writePackageJsonSync} from '../utils';
 
 export default function(program) {
   program
@@ -78,6 +78,12 @@ export default function(program) {
           console.log(`  ${green(figures.tick)} devDependencies installed`);
           console.log(`  ${green(figures.tick)} ${dirName} theme is ready`);
           console.log('');
+
+          return null;
+        })
+        .then(() => {
+          renameFile(join(root, 'config-sample.yml'), join(root, 'config.yml'));
+          renameFile(join(root, '.gitignore-sample', join(root, '.gitignore');
 
           return null;
         })

--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -89,7 +89,6 @@ export default function(program) {
           ];
 
           function renamePromiseFactory({oldFile, newFile, dir}) {
-            console.log(`  Renaming ${oldFile} to ${newFile}...`);
             return renameFile(join(dir, oldFile), join(dir, newFile));
           }
 

--- a/src/commands/theme.js
+++ b/src/commands/theme.js
@@ -81,11 +81,28 @@ export default function(program) {
 
           return null;
         })
-        .then(() => {
-          renameFile(join(root, 'config-sample.yml'), join(root, 'config.yml'));
-          renameFile(join(root, '.gitignore-sample', join(root, '.gitignore');
+        .then(async () => {
+
+          const sampleFiles = [
+            {oldFile: 'config-sample.yml', newFile: 'config.yml', dir: root},
+            {oldFile: '.gitignore-sample', newFile: '.gitignore', dir: root},
+          ];
+
+          function renamePromiseFactory({oldFile, newFile, dir}) {
+            console.log(`  Renaming ${oldFile} to ${newFile}...`);
+            return renameFile(join(dir, oldFile), join(dir, newFile));
+          }
+
+          const promises = sampleFiles.map(renamePromiseFactory);
+
+          try {
+            await Promise.all(promises);
+          } catch (err) {
+            console.error(red(`  ${err}`));
+          }
 
           return null;
+
         })
         .catch((err) => {
           console.error(red(`  ${err}`));

--- a/src/index.js
+++ b/src/index.js
@@ -54,9 +54,10 @@ const currentDirectory = __dirname;
 const workingDirectory = process.cwd();
 const pkg = require(join(currentDirectory, normalize('../package.json')));
 
+// Notify for updates every 1 week
 updateNotifier({
   pkg,
-  updateCheckInterval: 1000 * 60 * 60 * 24 * 7, // 1 week
+  updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
 }).notify();
 
 // Global commands

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,14 +79,18 @@ export function writePackageJsonSync(target, name = 'theme') {
 /**
  * Rename a file path
  *
- * @param {string} current - The path to the file currently.
- * @param {string} target - The renamed path of the file.
+ * @param {string} oldPath - The path to the file.
+ * @param {string} newPath - The path to the new file.
  */
-export function renameFile(current, target) {
-  rename(current, target, (err) => {
-    if (err) {
-      throw err;
-    }
+export function renameFile(oldPath, newPath) {
+  return new Promise((resolve, reject) => {
+    rename(oldPath, newPath, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
   });
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import {createReadStream, createWriteStream, unlinkSync, writeFileSync, existsSync} from 'fs';
+import {createReadStream, createWriteStream, rename, unlinkSync, writeFileSync, existsSync} from 'fs';
 import {join, normalize} from 'path';
 import {Extract} from 'unzip2';
 import {get} from 'https';
@@ -74,6 +74,20 @@ export function writePackageJsonSync(target, name = 'theme') {
   const data = JSON.stringify(pkg, null, 2);
 
   writeFileSync(target, data);
+}
+
+/**
+ * Rename a file path
+ *
+ * @param {string} current - The path to the file currently.
+ * @param {string} target - The renamed path of the file.
+ */
+export function renameFile(current, target) {
+  rename(current, target, (err) => {
+    if (err) {
+      throw err;
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
### What are you trying to accomplish with this PR?

Companion piece to this PR in `slate`: https://github.com/Shopify/slate/pull/179

The idea: After running `slate theme`, you are given an unzipped `slate-src.zip` plus two files `config-sample` and `.gitignore-sample`.  Let's save the manual effort of renaming both these files when you start off.


### Checklist
For contributors:
- [ ] I have updated the documentation in the [README file](https://github.com/Shopify/slate-cli/blob/master/README.md) to reflect these changes, if applicable.

For maintainers:
- [ ] I have :tophat:'d these changes.
- [ ] I have bumped the `package.json` version in a separate PR, if applicable.

Considerations:
- [ ] These changes will require the [public Slate docs](https://shopify.github.io/slate/) to be updated.  See the [Shopify/slate repo](https://github.com/Shopify/slate/blob/master/CONTRIBUTING.md#documentation) for notes on updating docs, if applicable.
